### PR TITLE
feat: Fix deprecated size aesthetic warning in visualization script

### DIFF
--- a/scripts/05_visualization.R
+++ b/scripts/05_visualization.R
@@ -85,7 +85,7 @@ premium_data <- premium_calc %>%
 # Create main finding visualization
 p1_premium_comparison <- ggplot(premium_data, aes(x = room_category, y = relative_premium_pct)) +
   geom_col(aes(fill = room_category), width = 0.6, alpha = 0.8) +
-  geom_hline(yintercept = 0, linetype = "dashed", color = "gray40", size = 0.8) +
+  geom_hline(yintercept = 0, linetype = "dashed", color = "gray40", linewidth = 0.8) +
   geom_text(aes(label = paste0(round(relative_premium_pct, 1), "%"), 
                 y = relative_premium_pct + ifelse(relative_premium_pct > 0, 2, -2)), 
             size = 5, fontface = "bold") +
@@ -193,7 +193,7 @@ stat_summary <- data.frame(
 p4_statistical_evidence <- ggplot(stat_summary, aes(x = reorder(Metric, Value), y = Value)) +
   geom_col(aes(fill = Significant), alpha = 0.8, width = 0.6) +
   geom_errorbar(aes(ymin = Lower_CI, ymax = Upper_CI), 
-                width = 0.2, size = 1, color = "black") +
+                width = 0.2, linewidth = 1, color = "black") +
   geom_hline(yintercept = 0, linetype = "dashed", color = "gray40") +
   geom_text(aes(label = paste0(round(Value, 1), "%")), 
             hjust = ifelse(stat_summary$Value > 0, -0.2, 1.2), 


### PR DESCRIPTION
## Summary
Clean up deprecated ggplot2 aesthetic usage to eliminate warnings and ensure compatibility with modern ggplot2 versions.

## Changes Made
- 🔧 Replaced deprecated `size` aesthetic with `linewidth` for line elements
- ✅ Fixed geom_hline and geom_errorbar deprecation warnings
- 📊 All visualization functionality preserved

## Visualizations Generated
- ✅ 01_premium_comparison.png: Core research finding  
- ✅ 02_price_distributions.png: Price distribution analysis
- ✅ 03_sample_sizes.png: Sample size validation  
- ✅ 04_statistical_evidence.png: Statistical significance summary
- ✅ 05_combined_academic_presentation.png: Combined academic figure

## Key Research Findings Visualized
- **Private Rooms: -22.19% premium** (Superhosts charge less\!)
- **Entire Places: +16.79% premium** (Superhosts charge more)  
- **38.98% differential** demonstrates sophisticated market segmentation

## Test Plan
- [x] Script runs without deprecation warnings
- [x] All 5 visualization files generated correctly
- [x] Academic quality maintained
- [x] No functional changes to plots